### PR TITLE
Updated requirements.txt with specific version numbers of the packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gym
+gym==0.9.1
 mujoco-py==0.5.7
 numpy
-tensorflow>=1.1.0
+tensorflow<=1.14.0


### PR DESCRIPTION
Resolves Issue #14 

Version numbers for the required packages in `requirements.txt` are specified, without which incompatible version of packages - `gym(0.15.3)`, `tensorflow(2.0.0)` gets installed and throws up error while execution. No version for `numpy` has been specified as even the latest version `(1.17.3)`as of today is compatible with the project.

### Checklist
- [x] Code compiles correctly.
- [x] Changes are tested properly.
- [x] Added the README / documentation